### PR TITLE
Add core Django app scaffold

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -47,6 +47,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "core",
 ]
 
 MIDDLEWARE = [

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core app package."""

--- a/core/admin.py
+++ b/core/admin.py
@@ -1,0 +1,3 @@
+"""Admin configuration for the core app."""
+
+from django.contrib import admin  # noqa: F401

--- a/core/apps.py
+++ b/core/apps.py
@@ -1,0 +1,10 @@
+"""Application configuration for the core app."""
+
+from django.apps import AppConfig
+
+
+class CoreConfig(AppConfig):
+    """Configuration for the core app."""
+
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "core"

--- a/core/models.py
+++ b/core/models.py
@@ -1,0 +1,3 @@
+"""Database models for the core app."""
+
+from django.db import models  # noqa: F401

--- a/core/tests.py
+++ b/core/tests.py
@@ -1,0 +1,3 @@
+"""Tests for the core app."""
+
+from django.test import TestCase  # noqa: F401

--- a/core/views.py
+++ b/core/views.py
@@ -1,0 +1,3 @@
+"""Views for the core app."""
+
+from django.shortcuts import render  # noqa: F401


### PR DESCRIPTION
## Summary
- start new `core` Django app
- register `core` in INSTALLED_APPS

## Testing
- `DJANGO_SECRET_KEY=dummy pre-commit run --files config/settings.py core/__init__.py core/admin.py core/apps.py core/models.py core/tests.py core/views.py`


------
https://chatgpt.com/codex/tasks/task_e_689b2389ab54832991c6966ea78b0648