### PR TITLE
Allow seeding for deterministic name generation

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -46,6 +46,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "core",
+    "tests",
 ]
 
 MIDDLEWARE = [

--- a/libs/__init__.py
+++ b/libs/__init__.py
@@ -1,0 +1,1 @@
+"""Helper libraries for Pro Sumo Manager."""

--- a/libs/generators/__init__.py
+++ b/libs/generators/__init__.py
@@ -1,0 +1,1 @@
+"""Generators for in-game data."""

--- a/libs/generators/name.py
+++ b/libs/generators/name.py
@@ -54,8 +54,15 @@ PHONEME_REPLACE = [
 class RikishiNameGenerator:
     """Generator for realistic-sounding sumo wrestler names."""
 
-    def __init__(self) -> None:
-        """Initialize the generator with probability tables and converters."""
+    def __init__(self, seed: int | None = None) -> None:
+        """
+        Initialize the generator.
+
+        Args:
+            seed: Optional seed for deterministic name generation.
+
+        """
+        self.random = random.Random(seed)
         self.len_prob: Sequence[float] = LEN_PROBABILITIES
         self.pos_table: PosTable = get_pos_table()
         self.kks = pykakasi.kakasi()
@@ -65,7 +72,7 @@ class RikishiNameGenerator:
         return "".join([r["hepburn"] for r in res])
 
     def __get_len(self) -> int:
-        return random.choices(
+        return self.random.choices(
             population=range(1, len(self.len_prob) + 1), weights=self.len_prob
         )[0]
 
@@ -80,7 +87,7 @@ class RikishiNameGenerator:
 
     def __check_valid(self, name: str, name_jp: str) -> bool:
         length = len(name)
-        max_len = random.choices(
+        max_len = self.random.choices(
             population=[LOW_MAX_NAME_LEN, MED_MAX_NAME_LEN, MAX_MAX_NAME_LEN],
             weights=[0.5, 0.4, 0.1],
         )[0]
@@ -92,7 +99,7 @@ class RikishiNameGenerator:
             name_jp = ""
             for i in range(self.__get_len()):
                 population, weights = zip(*self.pos_table[i], strict=False)
-                c = random.choices(population, weights)[0]
+                c = self.random.choices(population, weights)[0]
                 name_jp += c
             name = self.__transliterate(name_jp)
             name = self.__fix_phonemes(name)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite for pro-sumo-manager."""

--- a/tests/test_name_generator.py
+++ b/tests/test_name_generator.py
@@ -1,0 +1,15 @@
+"""Tests for the Rikishi name generator."""
+
+from django.test import SimpleTestCase
+
+from libs.generators.name import RikishiNameGenerator
+
+
+class RikishiNameGeneratorTests(SimpleTestCase):
+    """Tests for deterministic name generation."""
+
+    def test_seed_produces_deterministic_results(self) -> None:
+        """Two generators seeded the same produce identical names."""
+        gen1 = RikishiNameGenerator(seed=42)
+        gen2 = RikishiNameGenerator(seed=42)
+        self.assertEqual(gen1.get(), gen2.get())


### PR DESCRIPTION
## Summary
- add optional `seed` argument to `RikishiNameGenerator` and use an instance-specific PRNG
- create package init files for `libs` modules
- test that two generators with the same seed produce identical names using Django's `SimpleTestCase`
- register `tests` app so tests run via `python manage.py test`

## Testing
- `pre-commit run --files config/settings.py tests/__init__.py tests/test_name_generator.py`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689b6545392083298b0e6f8cd95e3131