### PR TITLE
Compile phoneme replacement patterns and test

### DIFF
--- a/libs/generators/name.py
+++ b/libs/generators/name.py
@@ -37,17 +37,16 @@ LEN_PROBABILITIES = [
 ]
 
 PHONEME_REPLACE = [
-    ("samurai", "ji"),
-    ("ryuu", "ryu"),
-    ("ooo", "oo"),
-    ("uoo", "uo"),
-    ("aoo", "ao"),
-    ("eoo", "eo"),
-    ("aoo", "ao"),
-    ("ioo", "io"),
-    (r"(?<![nhr])ou", "o"),
-    (r"ou$", "o"),
-    (r"uu$", "u"),
+    (re.compile("samurai"), "ji"),
+    (re.compile("ryuu"), "ryu"),
+    (re.compile("ooo"), "oo"),
+    (re.compile("uoo"), "uo"),
+    (re.compile("aoo"), "ao"),
+    (re.compile("eoo"), "eo"),
+    (re.compile("ioo"), "io"),
+    (re.compile(r"(?<![nhr])ou"), "o"),
+    (re.compile(r"ou$"), "o"),
+    (re.compile(r"uu$"), "u"),
 ]
 
 
@@ -77,8 +76,8 @@ class RikishiNameGenerator:
         )[0]
 
     def __fix_phonemes(self, name: str) -> str:
-        for phoneme in PHONEME_REPLACE:
-            name = re.sub(phoneme[0], phoneme[1], name)
+        for pattern, replacement in PHONEME_REPLACE:
+            name = pattern.sub(replacement, name)
         return name
 
     def __check_no(self, name_jp: str) -> bool:

--- a/tests/test_name_generator.py
+++ b/tests/test_name_generator.py
@@ -6,10 +6,20 @@ from libs.generators.name import RikishiNameGenerator
 
 
 class RikishiNameGeneratorTests(SimpleTestCase):
-    """Tests for deterministic name generation."""
+    """Tests for deterministic name generation and phoneme fixes."""
 
     def test_seed_produces_deterministic_results(self) -> None:
         """Two generators seeded the same produce identical names."""
         gen1 = RikishiNameGenerator(seed=42)
         gen2 = RikishiNameGenerator(seed=42)
         self.assertEqual(gen1.get(), gen2.get())
+
+    def test_fix_phonemes_replacements(self) -> None:
+        """Specific phoneme patterns are replaced correctly."""
+        gen = RikishiNameGenerator()
+        fix = gen._RikishiNameGenerator__fix_phonemes  # type: ignore[attr-defined]
+        self.assertEqual(fix("samurai"), "ji")
+        self.assertEqual(fix("ryuu"), "ryu")
+        self.assertEqual(fix("aoo"), "ao")
+        self.assertEqual(fix("sou"), "so")
+        self.assertEqual(fix("muu"), "mu")


### PR DESCRIPTION
## Summary
- Deduplicate phoneme replacement rules and compile regex patterns at import
- Update name generator to use compiled regex for phoneme fixes
- Add tests confirming phoneme replacements

## Testing
- `pre-commit run --files libs/generators/name.py tests/test_name_generator.py`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_689c526e040c83299c2e9db1b2b87b31