### PR TITLE
Ensure name generator respects minimum length

### DIFF
--- a/libs/generators/name.py
+++ b/libs/generators/name.py
@@ -29,11 +29,10 @@ MED_MAX_NAME_LEN = 19
 MAX_MAX_NAME_LEN = 24
 
 LEN_PROBABILITIES = [
-    0.025780189959294438,
-    0.39620081411126185,
-    0.4708276797829037,
-    0.1044776119402985,
-    0.0027137042062415195,
+    0.4066852367688022,
+    0.48328690807799446,
+    0.10724233983286907,
+    0.0027855153203342614,
 ]
 
 PHONEME_REPLACE = [
@@ -72,7 +71,8 @@ class RikishiNameGenerator:
 
     def __get_len(self) -> int:
         return self.random.choices(
-            population=range(1, len(self.len_prob) + 1), weights=self.len_prob
+            population=range(MIN_NAME_LEN, MIN_NAME_LEN + len(self.len_prob)),
+            weights=self.len_prob,
         )[0]
 
     def __fix_phonemes(self, name: str) -> str:

--- a/tests/test_name_generator.py
+++ b/tests/test_name_generator.py
@@ -2,7 +2,7 @@
 
 from django.test import SimpleTestCase
 
-from libs.generators.name import RikishiNameGenerator
+from libs.generators.name import MIN_NAME_LEN, RikishiNameGenerator
 
 
 class RikishiNameGeneratorTests(SimpleTestCase):
@@ -23,3 +23,11 @@ class RikishiNameGeneratorTests(SimpleTestCase):
         self.assertEqual(fix("aoo"), "ao")
         self.assertEqual(fix("sou"), "so")
         self.assertEqual(fix("muu"), "mu")
+
+    def test_generated_name_min_length(self) -> None:
+        """Generated names meet the minimum length requirement."""
+        gen = RikishiNameGenerator(seed=123)
+        for _ in range(100):
+            name, name_jp = gen.get()
+            self.assertGreaterEqual(len(name), MIN_NAME_LEN)
+            self.assertGreaterEqual(len(name_jp), MIN_NAME_LEN)


### PR DESCRIPTION
## Summary
- prevent generation of invalid short name lengths by starting length selection at `MIN_NAME_LEN`
- adjust length probabilities to match new minimum
- test generator always returns names at least `MIN_NAME_LEN` characters long

## Testing
- `pre-commit run --files libs/generators/name.py tests/test_name_generator.py`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_689c55399fc88329a862d995e9696ecf