### PR TITLE
Add limit to Rikishi name generation attempts

### DIFF
--- a/libs/generators/name.py
+++ b/libs/generators/name.py
@@ -27,6 +27,7 @@ MIN_NAME_LEN = 2
 LOW_MAX_NAME_LEN = 14
 MED_MAX_NAME_LEN = 19
 MAX_MAX_NAME_LEN = 24
+MAX_ATTEMPTS = 100
 
 LEN_PROBABILITIES = [
     0.4066852367688022,
@@ -93,8 +94,15 @@ class RikishiNameGenerator:
         return MIN_NAME_LEN <= length <= max_len and self.__check_no(name_jp)
 
     def get(self) -> tuple[str, str]:
-        """Return a tuple of (romanized name, Japanese name)."""
-        while True:
+        """
+        Return a tuple of (romanized name, Japanese name).
+
+        Raises:
+            RuntimeError: If a valid name cannot be generated within
+                ``MAX_ATTEMPTS``.
+
+        """
+        for _ in range(MAX_ATTEMPTS):
             name_jp = ""
             for i in range(self.__get_len()):
                 population, weights = zip(*self.pos_table[i], strict=False)
@@ -104,3 +112,6 @@ class RikishiNameGenerator:
             name = self.__fix_phonemes(name)
             if self.__check_valid(name, name_jp):
                 return (name, name_jp)
+        raise RuntimeError(
+            f"Failed to generate a valid name after {MAX_ATTEMPTS} attempts"
+        )

--- a/tests/test_name_generator.py
+++ b/tests/test_name_generator.py
@@ -1,5 +1,7 @@
 """Tests for the Rikishi name generator."""
 
+from unittest.mock import patch
+
 from django.test import SimpleTestCase
 
 from libs.generators.name import MIN_NAME_LEN, RikishiNameGenerator
@@ -31,3 +33,16 @@ class RikishiNameGeneratorTests(SimpleTestCase):
             name, name_jp = gen.get()
             self.assertGreaterEqual(len(name), MIN_NAME_LEN)
             self.assertGreaterEqual(len(name_jp), MIN_NAME_LEN)
+
+    def test_get_raises_after_max_attempts(self) -> None:
+        """An error is raised when a valid name can't be generated."""
+        gen = RikishiNameGenerator(seed=1)
+        with (
+            patch.object(
+                gen, "_RikishiNameGenerator__check_valid", return_value=False
+            ),
+            self.assertRaisesRegex(
+                RuntimeError, "Failed to generate a valid name"
+            ),
+        ):
+            gen.get()


### PR DESCRIPTION
## Summary
- add max attempts guard in `RikishiNameGenerator.get`
- raise an error when no valid name can be generated
- test that the generator raises after exceeding the limit

## Testing
- `pre-commit run --files libs/generators/name.py tests/test_name_generator.py`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_689c5fd465c48329bddafa6dc18df8d3