### PR TITLE
Add deterministic Rikishi name generator tests

### DIFF
--- a/tests/test_name_generator.py
+++ b/tests/test_name_generator.py
@@ -4,7 +4,11 @@ from unittest.mock import patch
 
 from django.test import SimpleTestCase
 
-from libs.generators.name import MIN_NAME_LEN, RikishiNameGenerator
+from libs.generators.name import (
+    MAX_MAX_NAME_LEN,
+    MIN_NAME_LEN,
+    RikishiNameGenerator,
+)
 
 
 class RikishiNameGeneratorTests(SimpleTestCase):
@@ -26,13 +30,38 @@ class RikishiNameGeneratorTests(SimpleTestCase):
         self.assertEqual(fix("sou"), "so")
         self.assertEqual(fix("muu"), "mu")
 
-    def test_generated_name_min_length(self) -> None:
-        """Generated names meet the minimum length requirement."""
+    def test_fix_phonemes_edge_cases(self) -> None:
+        """Edge cases for phoneme replacements are handled."""
+        gen = RikishiNameGenerator()
+        fix = gen._RikishiNameGenerator__fix_phonemes  # type: ignore[attr-defined]
+        self.assertEqual(fix("uoo"), "uo")
+        self.assertEqual(fix("eoo"), "eo")
+        self.assertEqual(fix("ioo"), "io")
+        self.assertEqual(fix("ooo"), "oo")
+        self.assertEqual(fix("nou"), "no")
+        self.assertEqual(fix("noui"), "noui")
+        self.assertEqual(fix("houi"), "houi")
+        self.assertEqual(fix("roui"), "roui")
+
+    def test_generated_name_length_constraints(self) -> None:
+        """Generated names meet length constraints."""
         gen = RikishiNameGenerator(seed=123)
         for _ in range(100):
             name, name_jp = gen.get()
             self.assertGreaterEqual(len(name), MIN_NAME_LEN)
             self.assertGreaterEqual(len(name_jp), MIN_NAME_LEN)
+            self.assertLessEqual(len(name), MAX_MAX_NAME_LEN)
+            self.assertLessEqual(len(name_jp), MAX_MAX_NAME_LEN)
+
+    def test_romanized_name_is_ascii_and_no_bounds(self) -> None:
+        """Romanized names are ASCII and don't start or end with 'no'."""
+        gen = RikishiNameGenerator(seed=8)
+        for _ in range(100):
+            name, _ = gen.get()
+            self.assertTrue(name.isascii())
+            lower = name.lower()
+            self.assertFalse(lower.startswith("no"))
+            self.assertFalse(lower.endswith("no"))
 
     def test_get_raises_after_max_attempts(self) -> None:
         """An error is raised when a valid name can't be generated."""


### PR DESCRIPTION
## Summary
- verify name generator enforces length constraints
- assert phoneme replacements handle edge cases
- ensure romanized names are ASCII and avoid `no` at boundaries

## Testing
- `pre-commit run --files tests/test_name_generator.py`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_689c7352c29483298b7940bd6cbe1761