### PR TITLE
Populate Shusshin table with all country and prefecture codes

### DIFF
--- a/core/migrations/0003_populate_shusshin.py
+++ b/core/migrations/0003_populate_shusshin.py
@@ -1,0 +1,37 @@
+from django.apps.registry import Apps
+from django.db import migrations
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+
+from core.enums import Country, JPPrefecture
+
+
+def populate_shusshin(
+    apps: Apps, schema_editor: BaseDatabaseSchemaEditor
+) -> None:
+    Shusshin = apps.get_model("core", "Shusshin")
+    for country in Country:
+        if country == Country.JP:
+            for prefecture in JPPrefecture:
+                Shusshin.objects.create(
+                    country_code=Country.JP,
+                    jp_prefecture=prefecture.value,
+                )
+        else:
+            Shusshin.objects.create(country_code=country.value)
+
+
+def unpopulate_shusshin(
+    apps: Apps, schema_editor: BaseDatabaseSchemaEditor
+) -> None:
+    Shusshin = apps.get_model("core", "Shusshin")
+    Shusshin.objects.all().delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0002_shusshin_unique_shusshin_country_except_japan_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(populate_shusshin, unpopulate_shusshin),
+    ]

--- a/tests/test_shusshin_model.py
+++ b/tests/test_shusshin_model.py
@@ -1,6 +1,7 @@
 """Tests for the Shusshin model."""
 
 from django.db import IntegrityError, transaction
+from django.db.models import Q
 from django.test import TestCase
 
 from core.enums.country_enum import Country
@@ -13,7 +14,7 @@ class ShusshinModelTests(TestCase):
 
     def test_str_returns_prefecture_label_for_japan(self) -> None:
         """Should return the prefecture label when country is Japan."""
-        shusshin = Shusshin.objects.create(
+        shusshin = Shusshin.objects.get(
             country_code=Country.JP,
             jp_prefecture=JPPrefecture.TOKYO,
         )
@@ -21,44 +22,47 @@ class ShusshinModelTests(TestCase):
 
     def test_str_returns_country_label_for_non_japan(self) -> None:
         """Should return the country label when not Japan."""
-        shusshin = Shusshin.objects.create(
-            country_code=Country.US,
-        )
+        shusshin = Shusshin.objects.get(country_code=Country.US)
         self.assertEqual(str(shusshin), "United States")
 
     def test_fail_with_jp_prefecture_if_not_japan(self) -> None:
         """Should fail if a non-Japanese Shusshin has a prefecture."""
+        shusshin = Shusshin.objects.get(country_code=Country.US)
         with self.assertRaises(IntegrityError), transaction.atomic():
-            Shusshin.objects.create(
-                country_code=Country.US,
-                jp_prefecture=JPPrefecture.TOKYO,
-            )
+            shusshin.jp_prefecture = JPPrefecture.TOKYO
+            shusshin.save()
 
     def test_fail_without_jp_prefecture_for_japan(self) -> None:
         """Should fail if a Japanese Shusshin is missing a prefecture."""
+        shusshin = Shusshin.objects.get(
+            country_code=Country.JP, jp_prefecture=JPPrefecture.TOKYO
+        )
         with self.assertRaises(IntegrityError), transaction.atomic():
-            Shusshin.objects.create(
-                country_code=Country.JP,
-            )
+            shusshin.jp_prefecture = ""
+            shusshin.save()
 
     def test_fail_duplicate_country_for_non_japan(self) -> None:
         """Should fail if two non-Japanese Shusshin share a country."""
-        Shusshin.objects.create(
-            country_code=Country.US,
-        )
         with self.assertRaises(IntegrityError), transaction.atomic():
-            Shusshin.objects.create(
-                country_code=Country.US,
-            )
+            Shusshin.objects.create(country_code=Country.US)
 
     def test_fail_duplicate_prefecture_for_japan(self) -> None:
         """Should fail if two Japanese Shusshin share a prefecture."""
-        Shusshin.objects.create(
-            country_code=Country.JP,
-            jp_prefecture=JPPrefecture.TOKYO,
-        )
         with self.assertRaises(IntegrityError), transaction.atomic():
             Shusshin.objects.create(
                 country_code=Country.JP,
                 jp_prefecture=JPPrefecture.TOKYO,
             )
+
+
+class ShusshinPopulationTests(TestCase):
+    """Tests for the populated Shusshin records."""
+
+    def test_all_shusshin_populated(self) -> None:
+        """Should have entries for every country and Japanese prefecture."""
+        non_jp_count = Shusshin.objects.filter(
+            ~Q(country_code=Country.JP)
+        ).count()
+        jp_count = Shusshin.objects.filter(country_code=Country.JP).count()
+        self.assertEqual(non_jp_count, len(list(Country)) - 1)
+        self.assertEqual(jp_count, len(list(JPPrefecture)))


### PR DESCRIPTION
## Summary
- add migration that seeds Shusshin for every country and each Japanese prefecture
- update Shusshin model tests for pre-populated data and verify all entries exist

## Testing
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_689ea5e886e4832980ff94c7855c1067