### PR TITLE
Extend Hepburn phoneme normalization

### DIFF
--- a/libs/generators/name.py
+++ b/libs/generators/name.py
@@ -113,6 +113,16 @@ PHONEME_REPLACE = [
     (re.compile(r"(?<![nhr])ou"), "o"),
     (re.compile(r"ou$"), "o"),
     (re.compile(r"uu$"), "u"),
+    # Hepburn adjustments for consistency across romanization
+    (re.compile(r"si"), "shi"),  # Convert Kunrei-shiki "si" to Hepburn "shi"
+    (re.compile(r"ti"), "chi"),  # Convert "ti" to "chi"
+    (re.compile(r"tu"), "tsu"),  # Convert "tu" to "tsu"
+    (re.compile(r"zi"), "ji"),  # Convert "zi" to "ji"
+    (re.compile(r"hu"), "fu"),  # Convert "hu" to "fu"
+    # Normalize long vowels by collapsing duplicates
+    (re.compile(r"aa"), "a"),
+    (re.compile(r"ii"), "i"),
+    (re.compile(r"ee"), "e"),
 ]
 
 

--- a/tests/test_name_generator.py
+++ b/tests/test_name_generator.py
@@ -61,6 +61,24 @@ class RikishiNameGeneratorTests(unittest.TestCase):
         )
         self.assertEqual(result, "ryu")
 
+    def test_fix_phonemes_hepburn_adjustments(self) -> None:
+        """Should normalize common Hepburn romanization patterns."""
+        generator = name.RikishiNameGenerator(seed=0)
+        cases = {
+            "si": "shi",
+            "ti": "chi",
+            "tu": "tsu",
+            "zi": "ji",
+            "hu": "fu",
+            "paa": "pa",
+        }
+        for raw, expected in cases.items():
+            with self.subTest(raw=raw):
+                result = generator._RikishiNameGenerator__fix_phonemes(  # type: ignore[attr-defined]
+                    raw
+                )
+                self.assertEqual(result, expected)
+
     def test_get_kanji_shikona_missing_start_bigram(self) -> None:
         """Should raise if the starting character has no bigrams."""
         generator = name.RikishiNameGenerator(seed=0)


### PR DESCRIPTION
## Summary
- expand phoneme replacement rules with common Hepburn conversions and long-vowel cleanup
- document phoneme normalization rules
- test Hepburn normalization patterns

## Testing
- `pre-commit run --files libs/generators/name.py tests/test_name_generator.py`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_689ef97388e88329898049175f320e58