### PR TITLE
Cache venv in CI and freeze uv sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
+        id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version-file: .python-version
@@ -30,8 +31,14 @@ jobs:
           version: "0.8.13"
           enable-cache: true
 
+      - name: Cache .venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: ${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('uv.lock') }}
+
       - name: Sync project
-        run: uv sync --locked --all-extras --dev
+        run: uv sync --frozen --all-extras --dev
 
       - name: Ruff (lint)
         uses: astral-sh/ruff-action@v3
@@ -52,6 +59,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
+        id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version-file: .python-version
@@ -62,8 +70,14 @@ jobs:
           version: "0.8.13"
           enable-cache: true
 
+      - name: Cache .venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: ${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('uv.lock') }}
+
       - name: Sync project
-        run: uv sync --locked --all-extras --dev
+        run: uv sync --frozen --all-extras --dev
 
       - name: Run tests (with coverage)
         run: ./test.sh


### PR DESCRIPTION
## Summary
- cache `.venv` across runs with `actions/cache`
- use `uv sync --frozen` in lint and test jobs

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ac3839ba9c832995d09fa90f2162f4