### PR TITLE
feat(#77): Add draft pool view for initial wrestler selection

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -9,12 +9,13 @@ from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
 
-from game.views import dashboard, index, setup_heya_name
+from game.views import dashboard, index, setup_draft_pool, setup_heya_name
 
 urlpatterns = [
     path("", index, name="index"),
     path("dashboard/", dashboard, name="dashboard"),
     path("setup/heya-name/", setup_heya_name, name="setup_heya_name"),
+    path("setup/draft/", setup_draft_pool, name="setup_draft_pool"),
     path("accounts/", include("allauth.urls")),
     path("admin/", admin.site.urls),
 ]

--- a/game/services/__init__.py
+++ b/game/services/__init__.py
@@ -1,6 +1,7 @@
 """Business logic services for the game app."""
 
 from .bout_service import BoutService
+from .draft_pool_service import DraftCandidate, DraftPoolService
 from .game_clock import GameClockService
 from .rikishi_service import RikishiService
 from .shikona_service import ShikonaService
@@ -8,6 +9,8 @@ from .training_service import TrainingService
 
 __all__ = [
     "BoutService",
+    "DraftCandidate",
+    "DraftPoolService",
     "GameClockService",
     "RikishiService",
     "ShikonaService",

--- a/game/services/draft_pool_service.py
+++ b/game/services/draft_pool_service.py
@@ -1,0 +1,228 @@
+"""Service for managing draft pool operations during game setup."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Self
+
+from libs.generators.rikishi import RikishiGenerator
+
+if TYPE_CHECKING:
+    from libs.types.rikishi import Rikishi
+
+
+@dataclass
+class DraftCandidate:
+    """A wrestler candidate in the draft pool with display-friendly data."""
+
+    shikona_name: str
+    shikona_transliteration: str
+    shusshin_display: str
+    strength: int
+    technique: int
+    balance: int
+    endurance: int
+    mental: int
+    potential_tier: str
+    # Store raw potential for internal use (not displayed)
+    _potential: int
+
+    def to_dict(self) -> dict[str, str | int]:
+        """Convert to dictionary for session storage."""
+        return {
+            "shikona_name": self.shikona_name,
+            "shikona_transliteration": self.shikona_transliteration,
+            "shusshin_display": self.shusshin_display,
+            "strength": self.strength,
+            "technique": self.technique,
+            "balance": self.balance,
+            "endurance": self.endurance,
+            "mental": self.mental,
+            "potential_tier": self.potential_tier,
+            "_potential": self._potential,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, str | int]) -> Self:
+        """Create from dictionary (session storage)."""
+        return cls(
+            shikona_name=str(data["shikona_name"]),
+            shikona_transliteration=str(data["shikona_transliteration"]),
+            shusshin_display=str(data["shusshin_display"]),
+            strength=int(data["strength"]),
+            technique=int(data["technique"]),
+            balance=int(data["balance"]),
+            endurance=int(data["endurance"]),
+            mental=int(data["mental"]),
+            potential_tier=str(data["potential_tier"]),
+            _potential=int(data["_potential"]),
+        )
+
+
+class DraftPoolService:
+    """
+    Service for generating and managing draft pools.
+
+    The draft pool is a set of generated wrestlers that a new player
+    can choose from to recruit for their stable.
+    """
+
+    # Potential tier mapping as specified in the issue
+    POTENTIAL_TIERS: list[tuple[int, int, str]] = [
+        (5, 20, "Limited"),
+        (21, 35, "Average"),
+        (36, 50, "Promising"),
+        (51, 70, "Talented"),
+        (71, 85, "Exceptional"),
+        (86, 100, "Generational"),
+    ]
+
+    MIN_POOL_SIZE = 5
+    MAX_POOL_SIZE = 8
+
+    @staticmethod
+    def get_potential_tier(potential: int) -> str:
+        """
+        Get the descriptive tier label for a potential value.
+
+        Args:
+            potential: The potential ability score (5-100).
+
+        Returns:
+            A descriptive tier label (e.g., "Promising", "Exceptional").
+
+        """
+        for min_val, max_val, label in DraftPoolService.POTENTIAL_TIERS:
+            if min_val <= potential <= max_val:
+                return label
+        # Fallback for edge cases (shouldn't happen with valid potentials)
+        return "Unknown"
+
+    @staticmethod
+    def generate_draft_pool(
+        seed: int | None = None,
+    ) -> list[DraftCandidate]:
+        """
+        Generate a pool of draft candidates.
+
+        Creates 5-8 wrestlers with varied potentials and stats for the
+        player to choose from during initial setup.
+
+        Args:
+            seed: Optional seed for deterministic generation (for testing).
+
+        Returns:
+            List of DraftCandidate objects representing available wrestlers.
+
+        """
+        rng = random.Random(seed)
+        pool_size = rng.randint(
+            DraftPoolService.MIN_POOL_SIZE,
+            DraftPoolService.MAX_POOL_SIZE,
+        )
+
+        generator = RikishiGenerator(seed=seed)
+        candidates: list[DraftCandidate] = []
+
+        for _ in range(pool_size):
+            rikishi = generator.get()
+            candidate = DraftPoolService._rikishi_to_candidate(rikishi)
+            candidates.append(candidate)
+
+        return candidates
+
+    @staticmethod
+    def _rikishi_to_candidate(rikishi: Rikishi) -> DraftCandidate:
+        """
+        Convert a generated Rikishi to a DraftCandidate.
+
+        Args:
+            rikishi: The generated Rikishi from RikishiGenerator.
+
+        Returns:
+            A DraftCandidate with display-friendly data.
+
+        """
+        # Build shusshin display string
+        shusshin = rikishi.shusshin
+        if shusshin.country_code == "JP" and shusshin.jp_prefecture:
+            # For Japanese wrestlers, show prefecture name
+            shusshin_display = DraftPoolService._prefecture_to_name(
+                shusshin.jp_prefecture
+            )
+        else:
+            # For foreign wrestlers, show country name
+            shusshin_display = DraftPoolService._country_to_name(
+                shusshin.country_code
+            )
+
+        return DraftCandidate(
+            shikona_name=rikishi.shikona.shikona,
+            shikona_transliteration=rikishi.shikona.transliteration,
+            shusshin_display=shusshin_display,
+            strength=rikishi.strength,
+            technique=rikishi.technique,
+            balance=rikishi.balance,
+            endurance=rikishi.endurance,
+            mental=rikishi.mental,
+            potential_tier=DraftPoolService.get_potential_tier(
+                rikishi.potential
+            ),
+            _potential=rikishi.potential,
+        )
+
+    @staticmethod
+    def _prefecture_to_name(prefecture_code: str) -> str:
+        """
+        Convert a JP prefecture code to a display name.
+
+        Args:
+            prefecture_code: ISO 3166-2 code like "JP-13" for Tokyo.
+
+        Returns:
+            Human-readable prefecture name.
+
+        """
+        # Import here to avoid circular dependencies
+        from game.enums.jp_prefecture_enum import JPPrefecture
+
+        try:
+            return str(JPPrefecture(prefecture_code).label)
+        except ValueError:
+            return prefecture_code
+
+    @staticmethod
+    def _country_to_name(country_code: str) -> str:
+        """
+        Convert a country code to a display name.
+
+        Args:
+            country_code: ISO 3166-1 alpha-2 code like "MN" for Mongolia.
+
+        Returns:
+            Human-readable country name.
+
+        """
+        # Import here to avoid circular dependencies
+        from game.enums.country_enum import Country
+
+        try:
+            return str(Country(country_code).label)
+        except ValueError:
+            return country_code
+
+    @staticmethod
+    def ensure_variety(candidates: list[DraftCandidate]) -> bool:
+        """
+        Check if the draft pool has sufficient variety in potentials.
+
+        Args:
+            candidates: List of draft candidates.
+
+        Returns:
+            True if the pool has at least 2 different potential tiers.
+
+        """
+        tiers = {c.potential_tier for c in candidates}
+        return len(tiers) >= 2

--- a/game/templates/game/setup/draft_pool.html
+++ b/game/templates/game/setup/draft_pool.html
@@ -1,0 +1,162 @@
+{% extends "game/base.html" %}
+
+{% block title %}Draft Your First Wrestler - Pro Sumo Manager{% endblock %}
+
+{% block content %}
+<div class="min-h-screen flex flex-col">
+    <!-- Header -->
+    <div class="navbar bg-base-200">
+        <div class="flex-1">
+            <span class="text-xl font-bold px-4">Pro Sumo Manager</span>
+        </div>
+        <div class="flex-none px-4">
+            <span class="text-sm opacity-70">{{ heya_name }} Stable</span>
+        </div>
+    </div>
+
+    <!-- Main Content -->
+    <div class="flex-1 p-6">
+        <div class="max-w-7xl mx-auto">
+            <!-- Title Section -->
+            <div class="text-center mb-8">
+                <h1 class="text-4xl font-bold mb-2">Draft Your First Wrestler</h1>
+                <p class="text-lg opacity-70">
+                    Choose a promising recruit to begin building your stable's legacy.
+                </p>
+            </div>
+
+            <!-- Messages -->
+            {% if messages %}
+            <div class="mb-6 max-w-2xl mx-auto">
+                {% for message in messages %}
+                <div class="alert alert-{{ message.tags }} mb-2">
+                    <span>{{ message }}</span>
+                </div>
+                {% endfor %}
+            </div>
+            {% endif %}
+
+            <!-- Selection Form -->
+            <form method="post" id="draft-form">
+                {% csrf_token %}
+
+                <!-- Wrestler Grid -->
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 mb-8">
+                    {% for candidate in candidates %}
+                    <label class="cursor-pointer">
+                        <input type="radio"
+                               name="selected_wrestler"
+                               value="{{ forloop.counter0 }}"
+                               class="hidden peer"
+                               {% if forloop.first %}checked{% endif %}>
+                        <div class="card bg-base-200 shadow-xl h-full transition-all duration-200
+                                    border-2 border-transparent
+                                    peer-checked:border-primary peer-checked:bg-base-300
+                                    hover:border-primary/50 hover:shadow-2xl">
+                            <div class="card-body">
+                                <!-- Name -->
+                                <div class="text-center mb-4">
+                                    <h2 class="text-3xl font-bold text-primary">
+                                        {{ candidate.shikona_name }}
+                                    </h2>
+                                    <p class="text-xl font-semibold">
+                                        {{ candidate.shikona_transliteration }}
+                                    </p>
+                                </div>
+
+                                <!-- Origin -->
+                                <div class="text-center mb-4">
+                                    <span class="badge badge-ghost badge-lg">
+                                        {{ candidate.shusshin_display }}
+                                    </span>
+                                </div>
+
+                                <!-- Potential Tier -->
+                                <div class="text-center mb-4">
+                                    <span class="badge
+                                        {% if candidate.potential_tier == 'Generational' %}badge-warning
+                                        {% elif candidate.potential_tier == 'Exceptional' %}badge-secondary
+                                        {% elif candidate.potential_tier == 'Talented' %}badge-primary
+                                        {% elif candidate.potential_tier == 'Promising' %}badge-info
+                                        {% elif candidate.potential_tier == 'Average' %}badge-ghost
+                                        {% else %}badge-neutral{% endif %}
+                                        badge-lg font-semibold">
+                                        {{ candidate.potential_tier }}
+                                    </span>
+                                </div>
+
+                                <div class="divider my-2"></div>
+
+                                <!-- Stats -->
+                                <div class="space-y-2">
+                                    <!-- Strength -->
+                                    <div class="flex items-center gap-2">
+                                        <span class="w-24 text-sm font-medium">Strength</span>
+                                        <progress class="progress progress-error flex-1"
+                                                  value="{{ candidate.strength }}" max="20"></progress>
+                                        <span class="w-6 text-right text-sm">{{ candidate.strength }}</span>
+                                    </div>
+                                    <!-- Technique -->
+                                    <div class="flex items-center gap-2">
+                                        <span class="w-24 text-sm font-medium">Technique</span>
+                                        <progress class="progress progress-warning flex-1"
+                                                  value="{{ candidate.technique }}" max="20"></progress>
+                                        <span class="w-6 text-right text-sm">{{ candidate.technique }}</span>
+                                    </div>
+                                    <!-- Balance -->
+                                    <div class="flex items-center gap-2">
+                                        <span class="w-24 text-sm font-medium">Balance</span>
+                                        <progress class="progress progress-success flex-1"
+                                                  value="{{ candidate.balance }}" max="20"></progress>
+                                        <span class="w-6 text-right text-sm">{{ candidate.balance }}</span>
+                                    </div>
+                                    <!-- Endurance -->
+                                    <div class="flex items-center gap-2">
+                                        <span class="w-24 text-sm font-medium">Endurance</span>
+                                        <progress class="progress progress-info flex-1"
+                                                  value="{{ candidate.endurance }}" max="20"></progress>
+                                        <span class="w-6 text-right text-sm">{{ candidate.endurance }}</span>
+                                    </div>
+                                    <!-- Mental -->
+                                    <div class="flex items-center gap-2">
+                                        <span class="w-24 text-sm font-medium">Mental</span>
+                                        <progress class="progress progress-secondary flex-1"
+                                                  value="{{ candidate.mental }}" max="20"></progress>
+                                        <span class="w-6 text-right text-sm">{{ candidate.mental }}</span>
+                                    </div>
+                                </div>
+
+                                <!-- Selection Indicator -->
+                                <div class="mt-4 text-center opacity-0 peer-checked:opacity-100 transition-opacity">
+                                    <span class="badge badge-primary badge-lg">Selected</span>
+                                </div>
+                            </div>
+                        </div>
+                    </label>
+                    {% endfor %}
+                </div>
+
+                <!-- Submit Button -->
+                <div class="text-center">
+                    <button type="submit" class="btn btn-primary btn-lg btn-wide">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 mr-2" fill="none"
+                             viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                  d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        </svg>
+                        Draft Wrestler
+                    </button>
+                </div>
+            </form>
+
+            <!-- Info -->
+            <div class="text-center mt-8">
+                <p class="text-sm opacity-50">
+                    Your first recruit will be the foundation of your stable.
+                    Choose based on potential and stats that match your strategy!
+                </p>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/tests/test_draft_pool_service.py
+++ b/tests/test_draft_pool_service.py
@@ -1,0 +1,296 @@
+"""Tests for the DraftPoolService."""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from game.services import DraftCandidate, DraftPoolService
+from libs.types.rikishi import Rikishi
+from libs.types.shikona import Shikona
+from libs.types.shusshin import Shusshin
+
+
+class TestGetPotentialTier(TestCase):
+    """Tests for DraftPoolService.get_potential_tier."""
+
+    def test_limited_tier_lower_bound(self) -> None:
+        """Should return 'Limited' for potential of 5."""
+        self.assertEqual(DraftPoolService.get_potential_tier(5), "Limited")
+
+    def test_limited_tier_upper_bound(self) -> None:
+        """Should return 'Limited' for potential of 20."""
+        self.assertEqual(DraftPoolService.get_potential_tier(20), "Limited")
+
+    def test_average_tier_lower_bound(self) -> None:
+        """Should return 'Average' for potential of 21."""
+        self.assertEqual(DraftPoolService.get_potential_tier(21), "Average")
+
+    def test_average_tier_upper_bound(self) -> None:
+        """Should return 'Average' for potential of 35."""
+        self.assertEqual(DraftPoolService.get_potential_tier(35), "Average")
+
+    def test_promising_tier_lower_bound(self) -> None:
+        """Should return 'Promising' for potential of 36."""
+        self.assertEqual(DraftPoolService.get_potential_tier(36), "Promising")
+
+    def test_promising_tier_upper_bound(self) -> None:
+        """Should return 'Promising' for potential of 50."""
+        self.assertEqual(DraftPoolService.get_potential_tier(50), "Promising")
+
+    def test_talented_tier_lower_bound(self) -> None:
+        """Should return 'Talented' for potential of 51."""
+        self.assertEqual(DraftPoolService.get_potential_tier(51), "Talented")
+
+    def test_talented_tier_upper_bound(self) -> None:
+        """Should return 'Talented' for potential of 70."""
+        self.assertEqual(DraftPoolService.get_potential_tier(70), "Talented")
+
+    def test_exceptional_tier_lower_bound(self) -> None:
+        """Should return 'Exceptional' for potential of 71."""
+        self.assertEqual(DraftPoolService.get_potential_tier(71), "Exceptional")
+
+    def test_exceptional_tier_upper_bound(self) -> None:
+        """Should return 'Exceptional' for potential of 85."""
+        self.assertEqual(DraftPoolService.get_potential_tier(85), "Exceptional")
+
+    def test_generational_tier_lower_bound(self) -> None:
+        """Should return 'Generational' for potential of 86."""
+        self.assertEqual(
+            DraftPoolService.get_potential_tier(86), "Generational"
+        )
+
+    def test_generational_tier_upper_bound(self) -> None:
+        """Should return 'Generational' for potential of 100."""
+        self.assertEqual(
+            DraftPoolService.get_potential_tier(100), "Generational"
+        )
+
+
+class TestGenerateDraftPool(TestCase):
+    """Tests for DraftPoolService.generate_draft_pool."""
+
+    @patch("game.services.draft_pool_service.RikishiGenerator")
+    def test_pool_size_within_bounds(self, mock_gen_class: MagicMock) -> None:
+        """Should generate between 5 and 8 wrestlers."""
+        mock_gen = mock_gen_class.return_value
+        mock_gen.get.return_value = Rikishi(
+            shikona=Shikona(
+                shikona="豊昇龍",
+                transliteration="Hoshoryu",
+                interpretation="Rising Dragon",
+            ),
+            shusshin=Shusshin(country_code="MN"),
+            potential=50,
+            current=20,
+            strength=5,
+            technique=5,
+            balance=5,
+            endurance=3,
+            mental=2,
+        )
+
+        # Test with multiple seeds to check pool size variation
+        for seed in range(100):
+            pool = DraftPoolService.generate_draft_pool(seed=seed)
+            self.assertGreaterEqual(
+                len(pool),
+                5,
+                f"Pool size {len(pool)} is less than minimum 5 (seed={seed})",
+            )
+            self.assertLessEqual(
+                len(pool),
+                8,
+                f"Pool size {len(pool)} exceeds maximum 8 (seed={seed})",
+            )
+
+    @patch("game.services.draft_pool_service.RikishiGenerator")
+    def test_pool_wrestlers_have_no_heya(
+        self, mock_gen_class: MagicMock
+    ) -> None:
+        """Generated wrestlers should not have a heya assigned."""
+        mock_gen = mock_gen_class.return_value
+        mock_gen.get.return_value = Rikishi(
+            shikona=Shikona(
+                shikona="豊昇龍",
+                transliteration="Hoshoryu",
+                interpretation="Rising Dragon",
+            ),
+            shusshin=Shusshin(country_code="MN"),
+            potential=50,
+            current=20,
+            strength=5,
+            technique=5,
+            balance=5,
+            endurance=3,
+            mental=2,
+        )
+
+        pool = DraftPoolService.generate_draft_pool(seed=42)
+
+        # DraftCandidate objects don't have heya - they're not DB models yet
+        # This is by design - they're candidates, not assigned wrestlers
+        for candidate in pool:
+            self.assertIsInstance(candidate, DraftCandidate)
+
+    @patch("game.services.draft_pool_service.RikishiGenerator")
+    def test_pool_has_potential_tier(self, mock_gen_class: MagicMock) -> None:
+        """All candidates should have a potential tier label."""
+        mock_gen = mock_gen_class.return_value
+        mock_gen.get.return_value = Rikishi(
+            shikona=Shikona(
+                shikona="豊昇龍",
+                transliteration="Hoshoryu",
+                interpretation="Rising Dragon",
+            ),
+            shusshin=Shusshin(country_code="MN"),
+            potential=50,
+            current=20,
+            strength=5,
+            technique=5,
+            balance=5,
+            endurance=3,
+            mental=2,
+        )
+
+        pool = DraftPoolService.generate_draft_pool(seed=42)
+
+        for candidate in pool:
+            self.assertIn(
+                candidate.potential_tier,
+                [
+                    "Limited",
+                    "Average",
+                    "Promising",
+                    "Talented",
+                    "Exceptional",
+                    "Generational",
+                ],
+            )
+
+    @patch("game.services.draft_pool_service.RikishiGenerator")
+    def test_pool_deterministic_with_seed(
+        self, mock_gen_class: MagicMock
+    ) -> None:
+        """Same seed should produce same pool size."""
+        mock_gen = mock_gen_class.return_value
+        mock_gen.get.return_value = Rikishi(
+            shikona=Shikona(
+                shikona="豊昇龍",
+                transliteration="Hoshoryu",
+                interpretation="Rising Dragon",
+            ),
+            shusshin=Shusshin(country_code="MN"),
+            potential=50,
+            current=20,
+            strength=5,
+            technique=5,
+            balance=5,
+            endurance=3,
+            mental=2,
+        )
+
+        pool1 = DraftPoolService.generate_draft_pool(seed=42)
+        pool2 = DraftPoolService.generate_draft_pool(seed=42)
+
+        self.assertEqual(len(pool1), len(pool2))
+
+
+class TestDraftCandidate(TestCase):
+    """Tests for the DraftCandidate dataclass."""
+
+    def test_to_dict_and_from_dict_roundtrip(self) -> None:
+        """Should serialize and deserialize correctly."""
+        candidate = DraftCandidate(
+            shikona_name="豊昇龍",
+            shikona_transliteration="Hoshoryu",
+            shusshin_display="Mongolia",
+            strength=5,
+            technique=6,
+            balance=4,
+            endurance=3,
+            mental=2,
+            potential_tier="Promising",
+            _potential=45,
+        )
+
+        data = candidate.to_dict()
+        restored = DraftCandidate.from_dict(data)
+
+        self.assertEqual(restored.shikona_name, candidate.shikona_name)
+        self.assertEqual(
+            restored.shikona_transliteration, candidate.shikona_transliteration
+        )
+        self.assertEqual(restored.shusshin_display, candidate.shusshin_display)
+        self.assertEqual(restored.strength, candidate.strength)
+        self.assertEqual(restored.technique, candidate.technique)
+        self.assertEqual(restored.balance, candidate.balance)
+        self.assertEqual(restored.endurance, candidate.endurance)
+        self.assertEqual(restored.mental, candidate.mental)
+        self.assertEqual(restored.potential_tier, candidate.potential_tier)
+        self.assertEqual(restored._potential, candidate._potential)
+
+
+class TestEnsureVariety(TestCase):
+    """Tests for DraftPoolService.ensure_variety."""
+
+    def test_variety_with_different_tiers(self) -> None:
+        """Should return True when pool has different potential tiers."""
+        candidates = [
+            DraftCandidate(
+                shikona_name="A",
+                shikona_transliteration="A",
+                shusshin_display="Japan",
+                strength=5,
+                technique=5,
+                balance=5,
+                endurance=5,
+                mental=5,
+                potential_tier="Promising",
+                _potential=40,
+            ),
+            DraftCandidate(
+                shikona_name="B",
+                shikona_transliteration="B",
+                shusshin_display="Japan",
+                strength=5,
+                technique=5,
+                balance=5,
+                endurance=5,
+                mental=5,
+                potential_tier="Average",
+                _potential=25,
+            ),
+        ]
+
+        self.assertTrue(DraftPoolService.ensure_variety(candidates))
+
+    def test_no_variety_with_same_tier(self) -> None:
+        """Should return False when all have same potential tier."""
+        candidates = [
+            DraftCandidate(
+                shikona_name="A",
+                shikona_transliteration="A",
+                shusshin_display="Japan",
+                strength=5,
+                technique=5,
+                balance=5,
+                endurance=5,
+                mental=5,
+                potential_tier="Average",
+                _potential=25,
+            ),
+            DraftCandidate(
+                shikona_name="B",
+                shikona_transliteration="B",
+                shusshin_display="Japan",
+                strength=5,
+                technique=5,
+                balance=5,
+                endurance=5,
+                mental=5,
+                potential_tier="Average",
+                _potential=30,
+            ),
+        ]
+
+        self.assertFalse(DraftPoolService.ensure_variety(candidates))

--- a/tests/test_setup_draft_pool.py
+++ b/tests/test_setup_draft_pool.py
@@ -1,0 +1,374 @@
+"""Tests for the draft pool setup flow."""
+
+from unittest.mock import MagicMock, patch
+
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from game.models import GameDate, Heya, Rikishi, Shikona
+from game.services import DraftCandidate
+
+User = get_user_model()
+
+
+class SetupDraftPoolViewTests(TestCase):
+    """Tests for the setup_draft_pool view."""
+
+    def setUp(self) -> None:
+        """Set up test data."""
+        self.client = Client()
+        self.user = User.objects.create_user(
+            email="test@example.com",
+            username="testuser",
+            password="testpass123",  # noqa: S106
+        )
+
+        # Create a heya for the user
+        self.game_date = GameDate.objects.create(year=1, month=1, day=1)
+        self.heya_name = Shikona.objects.create(
+            name="虎龍",
+            transliteration="Koryu",
+            interpretation="Tiger Dragon",
+        )
+        self.heya = Heya.objects.create(
+            name=self.heya_name,
+            created_at=self.game_date,
+            owner=self.user,
+        )
+
+    def test_draft_pool_requires_login(self) -> None:
+        """Draft pool page should redirect unauthenticated users."""
+        response = self.client.get(reverse("setup_draft_pool"))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/accounts/login/", response.url)
+
+    def test_draft_pool_requires_heya(self) -> None:
+        """Draft pool page should redirect users without a heya."""
+        # Use a fresh client to avoid session contamination from other tests
+        client = Client()
+
+        # Create user without heya
+        user_no_heya = User.objects.create_user(
+            email="noheya@example.com",
+            username="noheya",
+            password="testpass123",  # noqa: S106
+        )
+        client.force_login(user_no_heya)
+
+        response = client.get(reverse("setup_draft_pool"))
+        # fetch_redirect_response=False to avoid following to setup_heya_name
+        # which would trigger ShikonaGenerator with mocked OpenAI
+        self.assertRedirects(
+            response,
+            reverse("setup_heya_name"),
+            fetch_redirect_response=False,
+        )
+
+    def test_draft_pool_redirects_if_already_drafted(self) -> None:
+        """Draft pool page should redirect users who already have a wrestler."""
+        # Create a wrestler for the heya
+        wrestler_shikona = Shikona.objects.create(
+            name="大海",
+            transliteration="Oumi",
+            interpretation="Great Sea",
+        )
+        Rikishi.objects.create(
+            shikona=wrestler_shikona,
+            heya=self.heya,
+            potential=50,
+            strength=5,
+            technique=5,
+            balance=5,
+            endurance=3,
+            mental=2,
+        )
+
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("setup_draft_pool"))
+        self.assertRedirects(response, reverse("dashboard"))
+
+    @patch("game.views.DraftPoolService.generate_draft_pool")
+    def test_draft_pool_page_renders(self, mock_generate: MagicMock) -> None:
+        """Draft pool page should render successfully."""
+        mock_generate.return_value = [
+            DraftCandidate(
+                shikona_name="豊昇龍",
+                shikona_transliteration="Hoshoryu",
+                shusshin_display="Mongolia",
+                strength=5,
+                technique=6,
+                balance=4,
+                endurance=3,
+                mental=2,
+                potential_tier="Promising",
+                _potential=45,
+            ),
+        ]
+
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("setup_draft_pool"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Draft Your First Wrestler")
+        self.assertContains(response, "Hoshoryu")
+        self.assertContains(response, "Mongolia")
+        self.assertContains(response, "Promising")
+
+    @patch("game.views.DraftPoolService.generate_draft_pool")
+    def test_draft_pool_stored_in_session(
+        self, mock_generate: MagicMock
+    ) -> None:
+        """Draft pool should be stored in session for consistency."""
+        mock_generate.return_value = [
+            DraftCandidate(
+                shikona_name="豊昇龍",
+                shikona_transliteration="Hoshoryu",
+                shusshin_display="Mongolia",
+                strength=5,
+                technique=6,
+                balance=4,
+                endurance=3,
+                mental=2,
+                potential_tier="Promising",
+                _potential=45,
+            ),
+        ]
+
+        self.client.force_login(self.user)
+        self.client.get(reverse("setup_draft_pool"))
+
+        # Second request should not regenerate
+        mock_generate.reset_mock()
+        self.client.get(reverse("setup_draft_pool"))
+        mock_generate.assert_not_called()
+
+    @patch("game.views.DraftPoolService.generate_draft_pool")
+    def test_draft_pool_persists_across_reloads(
+        self, mock_generate: MagicMock
+    ) -> None:
+        """Draft pool should persist in session across page reloads."""
+        mock_generate.return_value = [
+            DraftCandidate(
+                shikona_name="豊昇龍",
+                shikona_transliteration="Hoshoryu",
+                shusshin_display="Mongolia",
+                strength=5,
+                technique=6,
+                balance=4,
+                endurance=3,
+                mental=2,
+                potential_tier="Promising",
+                _potential=45,
+            ),
+        ]
+
+        self.client.force_login(self.user)
+
+        # First request
+        response1 = self.client.get(reverse("setup_draft_pool"))
+        self.assertContains(response1, "Hoshoryu")
+
+        # Second request (reload)
+        response2 = self.client.get(reverse("setup_draft_pool"))
+        self.assertContains(response2, "Hoshoryu")
+
+        # generate_draft_pool should only be called once
+        mock_generate.assert_called_once()
+
+    @patch("game.views.DraftPoolService.generate_draft_pool")
+    def test_draft_selection_creates_wrestler(
+        self, mock_generate: MagicMock
+    ) -> None:
+        """Selecting a wrestler should create a Rikishi record."""
+        mock_generate.return_value = [
+            DraftCandidate(
+                shikona_name="豊昇龍",
+                shikona_transliteration="Hoshoryu",
+                shusshin_display="Mongolia",
+                strength=5,
+                technique=6,
+                balance=4,
+                endurance=3,
+                mental=2,
+                potential_tier="Promising",
+                _potential=45,
+            ),
+        ]
+
+        self.client.force_login(self.user)
+
+        # Load the page to populate session
+        self.client.get(reverse("setup_draft_pool"))
+
+        # Submit selection
+        response = self.client.post(
+            reverse("setup_draft_pool"),
+            {"selected_wrestler": "0"},
+        )
+
+        # Should redirect to dashboard
+        self.assertRedirects(response, reverse("dashboard"))
+
+        # Rikishi should be created
+        self.assertTrue(Rikishi.objects.filter(shikona__name="豊昇龍").exists())
+
+        # Rikishi should belong to user's heya
+        rikishi = Rikishi.objects.get(shikona__name="豊昇龍")
+        self.assertEqual(rikishi.heya, self.heya)
+        self.assertEqual(rikishi.potential, 45)
+        self.assertEqual(rikishi.strength, 5)
+        self.assertEqual(rikishi.technique, 6)
+
+    @patch("game.views.DraftPoolService.generate_draft_pool")
+    def test_draft_selection_without_selection_shows_error(
+        self, mock_generate: MagicMock
+    ) -> None:
+        """Submitting without selection should show error."""
+        mock_generate.return_value = [
+            DraftCandidate(
+                shikona_name="豊昇龍",
+                shikona_transliteration="Hoshoryu",
+                shusshin_display="Mongolia",
+                strength=5,
+                technique=6,
+                balance=4,
+                endurance=3,
+                mental=2,
+                potential_tier="Promising",
+                _potential=45,
+            ),
+        ]
+
+        self.client.force_login(self.user)
+        self.client.get(reverse("setup_draft_pool"))
+
+        response = self.client.post(reverse("setup_draft_pool"), {})
+        self.assertRedirects(response, reverse("setup_draft_pool"))
+
+    @patch("game.views.DraftPoolService.generate_draft_pool")
+    def test_draft_selection_invalid_index_shows_error(
+        self, mock_generate: MagicMock
+    ) -> None:
+        """Invalid selection index should show error."""
+        mock_generate.return_value = [
+            DraftCandidate(
+                shikona_name="豊昇龍",
+                shikona_transliteration="Hoshoryu",
+                shusshin_display="Mongolia",
+                strength=5,
+                technique=6,
+                balance=4,
+                endurance=3,
+                mental=2,
+                potential_tier="Promising",
+                _potential=45,
+            ),
+        ]
+
+        self.client.force_login(self.user)
+        self.client.get(reverse("setup_draft_pool"))
+
+        response = self.client.post(
+            reverse("setup_draft_pool"),
+            {"selected_wrestler": "99"},  # Invalid index
+        )
+        self.assertRedirects(response, reverse("setup_draft_pool"))
+
+    @patch("game.views.DraftPoolService.generate_draft_pool")
+    def test_draft_clears_session_on_success(
+        self, mock_generate: MagicMock
+    ) -> None:
+        """Session should be cleared after successful draft."""
+        mock_generate.return_value = [
+            DraftCandidate(
+                shikona_name="豊昇龍",
+                shikona_transliteration="Hoshoryu",
+                shusshin_display="Mongolia",
+                strength=5,
+                technique=6,
+                balance=4,
+                endurance=3,
+                mental=2,
+                potential_tier="Promising",
+                _potential=45,
+            ),
+        ]
+
+        self.client.force_login(self.user)
+        self.client.get(reverse("setup_draft_pool"))
+
+        # Verify session has data
+        session = self.client.session
+        self.assertIn("draft_pool", session)
+
+        # Submit selection
+        self.client.post(
+            reverse("setup_draft_pool"),
+            {"selected_wrestler": "0"},
+        )
+
+        # Session should be cleared (need fresh session object)
+        session = self.client.session
+        self.assertNotIn("draft_pool", session)
+
+    @patch("game.views.DraftPoolService.generate_draft_pool")
+    def test_draft_pool_displays_all_stats(
+        self, mock_generate: MagicMock
+    ) -> None:
+        """Draft pool should display all 5 stats for each wrestler."""
+        mock_generate.return_value = [
+            DraftCandidate(
+                shikona_name="豊昇龍",
+                shikona_transliteration="Hoshoryu",
+                shusshin_display="Mongolia",
+                strength=8,
+                technique=7,
+                balance=6,
+                endurance=5,
+                mental=4,
+                potential_tier="Talented",
+                _potential=55,
+            ),
+        ]
+
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("setup_draft_pool"))
+
+        self.assertContains(response, "Strength")
+        self.assertContains(response, "Technique")
+        self.assertContains(response, "Balance")
+        self.assertContains(response, "Endurance")
+        self.assertContains(response, "Mental")
+
+    @patch("game.views.DraftPoolService.generate_draft_pool")
+    def test_draft_pool_shows_potential_tier_not_number(
+        self, mock_generate: MagicMock
+    ) -> None:
+        """Draft pool should show tier label, not the potential number."""
+        mock_generate.return_value = [
+            DraftCandidate(
+                shikona_name="豊昇龍",
+                shikona_transliteration="Hoshoryu",
+                shusshin_display="Mongolia",
+                strength=5,
+                technique=6,
+                balance=4,
+                endurance=3,
+                mental=2,
+                potential_tier="Exceptional",
+                _potential=75,
+            ),
+        ]
+
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("setup_draft_pool"))
+
+        # Should show tier label
+        self.assertContains(response, "Exceptional")
+
+        # Should NOT show the actual potential number
+        content = response.content.decode()
+        # Check that "75" doesn't appear as a standalone value
+        # (it might appear in other contexts like CSS values)
+        self.assertNotIn(">75<", content)


### PR DESCRIPTION
## Summary
Implements story 1.2: View Draft Pool

After selecting a heya name, players are now presented with a pool of 5-8 generated wrestlers to choose from for their initial roster.

## Changes
- **DraftPoolService**: New service for generating draft pools with potential tier mapping
- **SetupDraftPoolView**: New view handling GET (display pool) and POST (draft selection)
- **draft_pool.html**: New template with DaisyUI cards, stat progress bars, and potential tier badges
- **URL route**: `/setup/draft/` added
- **Redirect flow**: setup_heya_name now redirects to draft pool instead of dashboard

## Features
- Generates 5-8 wrestlers with varied potential/stats
- Displays wrestler cards with:
  - Ring name (Shikona) - Japanese and transliteration
  - Place of origin (Shusshin)
  - All 5 stats with progress bar visualization
  - Potential tier indicator (Limited → Generational)
- Session storage for draft pool persistence across page reloads
- Clickable cards with visual selection indicator

## Tests
- Unit tests for potential tier mapping (all 6 tiers)
- Unit tests for draft pool generation (5-8 wrestlers, varied potentials)
- Integration tests for view (auth, redirects, selection, session handling)

Closes #77